### PR TITLE
Changed URL creation to handle WinOS paths

### DIFF
--- a/juseppe-cli/src/test/java/ru/lanwen/jenkins/juseppe/cli/ServeRule.java
+++ b/juseppe-cli/src/test/java/ru/lanwen/jenkins/juseppe/cli/ServeRule.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import ru.lanwen.jenkins.juseppe.props.Props;
 
 import java.io.IOException;
+import java.io.File;
 import java.net.ServerSocket;
 import java.net.URI;
 import java.util.concurrent.CompletableFuture;
@@ -24,14 +25,19 @@ public class ServeRule extends ExternalResource {
 
     @Override
     protected void before() throws Throwable {
+        ClassLoader classloader = getClass().getClassLoader();
+        File plugins = new File(classloader.getResource("serve/plugins").getFile());
+        File key = new File(classloader.getResource("serve/cert/uc.key").getFile());
+        File crt = new File(classloader.getResource("serve/cert/uc.crt").getFile());
         port = findRandomOpenPortOnAllLocalInterfaces();
+
         future = CompletableFuture.runAsync(() -> {
             try {
                 new ServeCommand().unsafeRun(Props.populated()
                         .withBaseurl(uri())
-                        .withPluginsDir(getResource("serve/plugins").getFile())
-                        .withCert(getResource("serve/cert/uc.crt").getFile())
-                        .withKey(getResource("serve/cert/uc.key").getFile())
+                        .withPluginsDir(plugins.toString())
+                        .withCert(crt.toString())
+                        .withKey(key.toString())
                         .withPort(port));
             } catch (Exception e) {
                 LOG.error("Can't start juseppe", e);

--- a/juseppe-core/src/main/java/ru/lanwen/jenkins/juseppe/gen/UpdateSiteGen.java
+++ b/juseppe-core/src/main/java/ru/lanwen/jenkins/juseppe/gen/UpdateSiteGen.java
@@ -58,7 +58,7 @@ public class UpdateSiteGen {
                         .forEach(source -> site.getPlugins().addAll(source.plugins()))
         ).register(
                 site -> site.getPlugins()
-                        .forEach(plugin -> plugin.setUrl(format("%s/%s", props.getBaseurl(), plugin.getUrl())))
+                        .forEach(plugin -> plugin.setUrl(format("%s/%s", props.getBaseurl(), plugin.getUrl()).replace("\\", "/")))
         ).register(
                 site -> {
                     try {

--- a/juseppe-core/src/test/java/ru/lanwen/jenkins/juseppe/HPICreationTest.java
+++ b/juseppe-core/src/test/java/ru/lanwen/jenkins/juseppe/HPICreationTest.java
@@ -40,7 +40,6 @@ public class HPICreationTest {
         @Override
         protected void before() throws Throwable {
             folderToSave = tmp.newFolder();
-            System.out.println(folderToSave.getAbsolutePath());
             clearProperty(JuseppeEnvVars.JuseppeEnvEnum.JUSEPPE_SAVE_TO_DIR.mapping());
             setProperty(JuseppeEnvVars.JuseppeEnvEnum.JUSEPPE_SAVE_TO_DIR.mapping(), folderToSave.getAbsolutePath());
         }
@@ -51,10 +50,12 @@ public class HPICreationTest {
     @Test
     public void shouldSaveJsonWithPluginInfo() throws IOException {
         File file = tmp.newFile("temp.json");
+        ClassLoader classloader = getClass().getClassLoader();
+        File fullFilePath = new File(classloader.getResource(PLUGINS_DIR_CLASSPATH).getFile());
 
         updateSite(
                 Props.populated()
-                        .withPluginsDir(getResource(PLUGINS_DIR_CLASSPATH).getFile())
+                        .withPluginsDir(fullFilePath.toString())
                         .withBaseurl(URI.create(BASE_URL_OF_SITE))
                         .withSaveto(file.getParent())
                         .withUcJsonName(file.getName())
@@ -67,9 +68,11 @@ public class HPICreationTest {
     @Test
     public void shouldSaveJsonWithReleaseHistory() throws IOException {
         File file = new File(folderToSave, Props.populated().getReleaseHistoryJsonName());
+        ClassLoader classloader = getClass().getClassLoader();
+        File fullFilePath = new File(classloader.getResource(PLUGINS_DIR_CLASSPATH).getFile());
 
         UpdateSiteGen.updateSite(Props.populated()
-                .withPluginsDir(getResource(PLUGINS_DIR_CLASSPATH).getFile())).withDefaults().toSave().saveAll();
+                .withPluginsDir(fullFilePath.toString())).withDefaults().toSave().saveAll();
 
         assertThat(file, exists());
         assertThat(file.length(), greaterThan(200l));
@@ -77,8 +80,11 @@ public class HPICreationTest {
 
     @Test
     public void shouldContainPlugin() throws IOException {
+        ClassLoader classloader = getClass().getClassLoader();
+        File fullFilePath = new File(classloader.getResource(PLUGINS_DIR_CLASSPATH).getFile());
+
         List<String> contents = UpdateSiteGen.updateSite(Props.populated()
-                .withPluginsDir(getResource(PLUGINS_DIR_CLASSPATH).getFile())).withDefaults().toSave()
+                .withPluginsDir(fullFilePath.toString())).withDefaults().toSave()
                 .savables().stream()
                 .map(SavableSite::getView)
                 .map(UpdateSiteView::content)

--- a/juseppe-core/src/test/java/ru/lanwen/jenkins/juseppe/gen/source/PathPluginSourceTest.java
+++ b/juseppe-core/src/test/java/ru/lanwen/jenkins/juseppe/gen/source/PathPluginSourceTest.java
@@ -4,6 +4,8 @@ import org.junit.Test;
 import ru.lanwen.jenkins.juseppe.beans.Plugin;
 
 import java.nio.file.Paths;
+import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
 
 import static com.google.common.io.Resources.getResource;
@@ -21,7 +23,10 @@ public class PathPluginSourceTest {
     @Test
     public void shouldFindAllPlugins() throws Exception {
         boolean recursiveWatch = false;
-        List<Plugin> plugins = new PathPluginSource(Paths.get(getResource(PLUGINS_DIR_CLASSPATH).getFile()),
+        ClassLoader classloader = getClass().getClassLoader();
+        File file = new File(classloader.getResource(PLUGINS_DIR_CLASSPATH).getFile());
+        Path path = file.toPath();
+        List<Plugin> plugins = new PathPluginSource(path,
                                                     recursiveWatch)
                 .plugins();
 
@@ -33,7 +38,10 @@ public class PathPluginSourceTest {
     @Test
     public void shouldFindAllPluginsRecursively() throws Exception {
         boolean recursiveWatch = true;
-        List<Plugin> plugins = new PathPluginSource(Paths.get(getResource(PLUGINS_DIR_CLASSPATH).getFile()),
+        ClassLoader classloader = getClass().getClassLoader();
+        File file = new File(classloader.getResource(PLUGINS_DIR_CLASSPATH).getFile());
+        Path path = file.toPath();
+        List<Plugin> plugins = new PathPluginSource(path,
                                                     recursiveWatch)
                  .plugins();
 


### PR DESCRIPTION
Changed one line to replace '\' in Windows file paths to '/' so that URLs are created correctly when Juseppe is used on a Windows machine.