### PR TITLE
Condense and update `.travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 language: java
-sudo: false
 
 jdk:
- - oraclejdk8
+  - openjdk8
+
+before_install:
+  - chmod +x gradlew
+
+script:
+  - ./gradlew check
+  - ./gradlew cobertura
 
 after_success:
-  - mvn clean cobertura:cobertura -Dcobertura.report.format=xml org.eluder.coveralls:coveralls-maven-plugin:3.1.0:report
+  - bash <(curl -s https://codecov.io/bash)
 
 notifications:
- email: false
+  email: false


### PR DESCRIPTION
- Use OpenJDK 8 instead of Oracle JDK 8.
- Added a `before_install` step to make the `gradlew` script executable using `chmod +x`. 
- Use `./gradlew` for building and running tests instead of Maven.
- Generate Cobertura coverage and upload to Codecov instead of Coveralls.
- Removed unused `sudo` key.